### PR TITLE
Allow library path to be specified in env

### DIFF
--- a/pylibhackrf.py
+++ b/pylibhackrf.py
@@ -13,7 +13,7 @@ logging.basicConfig()
 logger = logging.getLogger('HackRf Core')
 logger.setLevel(logging.DEBUG)
 
-libhackrf = CDLL('/usr/local/lib/libhackrf.so')
+libhackrf = CDLL(os.environ.get('LIBHACKRF', '/usr/local/lib/libhackrf.so'))
 
 def enum(*sequential, **named):
     enums = dict(zip(sequential, range(len(sequential))), **named)


### PR DESCRIPTION
This helps people who have this installed in non-standard paths (e.g.,
for a Nix environment). The default here only seems valid for a very
typical autoconf setup with PREFIX=/usr/local.